### PR TITLE
fix normalization

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,7 +14,7 @@ authors:
     affiliation: Netherlands eScience Center
     orcid: 'https://orcid.org/0000-0002-5373-5209'
 date-released: 2024-10-08
-version: "0.4.1"
+version: "0.4.2"
 repository-code: "https://github.com/DroneML/pycoeus"
 keywords:
   - "Segmentation"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ author = u"Christiaan Meijer"
 # built documents.
 #
 # The short X.Y version.
-version = "0.4.1"
+version = "0.4.2"
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ license = {file = "LICENSE"}
 name = "pycoeus"
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.8"
-version = "0.4.1"
+version = "0.4.2"
 
 [project.optional-dependencies]
 train = [
@@ -150,7 +150,7 @@ force-single-line = true
 no-lines-before = ["future","standard-library","third-party","first-party","local-folder"]
 
 [tool.bumpversion]
-current_version = "0.4.1"
+current_version = "0.4.2"
 
 [[tool.bumpversion.files]]
 filename = "src/pycoeus/__init__.py"

--- a/src/pycoeus/__init__.py
+++ b/src/pycoeus/__init__.py
@@ -6,4 +6,4 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __author__ = "Christiaan Meijer"
 __email__ = "c.meijer@esciencecenter.nl"
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/src/pycoeus/features.py
+++ b/src/pycoeus/features.py
@@ -153,11 +153,14 @@ def extract_flair_features(input_data: ndarray, model_scale=1.0) -> ndarray:
 
     outputs = []
     for i_band in range(n_bands):
-        input_band = normalize_single_band_to_tensor(input_data[i_band:i_band + 1, :, :])[None, :, :, :].float().to(
-            device)
+        # input_band = normalize_single_band_to_tensor(input_data[i_band:i_band + 1, :, :])[None, :, :, :].float().to(
+        #     device)
+        input_band = torch.from_numpy(input_data[None, i_band : i_band + 1, :, :]).float().to(device)
         padded_input = pad(input_band, band_name=i_band)
-        padded_current_predictions = model(padded_input)
-        current_predictions = unpad(padded_current_predictions, input_band.shape).detach().numpy()
+        # padded_current_predictions = model(padded_input)
+        # current_predictions = unpad(padded_current_predictions, input_band.shape).detach().numpy()
+        padded_current_predictions = model(padded_input).detach().numpy()
+        current_predictions = padded_current_predictions[:, :, : input_band.shape[2], : input_band.shape[3]]  # unpad
         outputs.append(current_predictions)
     output = np.concatenate(outputs, axis=1)
     return output[0, :, :, :]

--- a/src/pycoeus/features.py
+++ b/src/pycoeus/features.py
@@ -153,14 +153,11 @@ def extract_flair_features(input_data: ndarray, model_scale=1.0) -> ndarray:
 
     outputs = []
     for i_band in range(n_bands):
-        # input_band = normalize_single_band_to_tensor(input_data[i_band:i_band + 1, :, :])[None, :, :, :].float().to(
-        #     device)
-        input_band = torch.from_numpy(input_data[None, i_band : i_band + 1, :, :]).float().to(device)
+        input_band = normalize_single_band_to_tensor(input_data[i_band:i_band + 1, :, :])[None, :, :, :].float().to(
+            device)
         padded_input = pad(input_band, band_name=i_band)
-        # padded_current_predictions = model(padded_input)
-        # current_predictions = unpad(padded_current_predictions, input_band.shape).detach().numpy()
-        padded_current_predictions = model(padded_input).detach().numpy()
-        current_predictions = padded_current_predictions[:, :, : input_band.shape[2], : input_band.shape[3]]  # unpad
+        padded_current_predictions = model(padded_input)
+        current_predictions = unpad(padded_current_predictions, input_band.shape).detach().numpy()
         outputs.append(current_predictions)
     output = np.concatenate(outputs, axis=1)
     return output[0, :, :, :]

--- a/src/pycoeus/utils/datasets.py
+++ b/src/pycoeus/utils/datasets.py
@@ -38,12 +38,19 @@ class MonochromeFlairDataset(Dataset):
         return min(len(self.images), self.limit)
 
 def normalize_single_band_to_tensor(img_arr: np.ndarray, debug_note="") -> torch.Tensor:
-    std = img_arr.std()
+    
+    # Remove min and max values from the array
+    img_arr_data = img_arr.flatten()
+    img_arr_data = img_arr_data[img_arr_data != img_arr_data.min()]
+    img_arr_data = img_arr_data[img_arr_data != img_arr_data.max()]
+
+    std = img_arr_data.std()
     if std == 0:
         msg = "Standard deviation = 0 " + debug_note
         logger.debug(msg)
         std = 1
-    normalized = (img_arr - img_arr.mean()) / std
+    mean = img_arr_data.mean()
+    normalized = (img_arr - mean) / std
     return torch.from_numpy(normalized)
 
 

--- a/src/pycoeus/utils/datasets.py
+++ b/src/pycoeus/utils/datasets.py
@@ -41,8 +41,12 @@ def normalize_single_band_to_tensor(img_arr: np.ndarray, debug_note="") -> torch
     
     # Remove min and max values from the array
     img_arr_data = img_arr.flatten()
-    img_arr_data = img_arr_data[img_arr_data != img_arr_data.min()]
-    img_arr_data = img_arr_data[img_arr_data != img_arr_data.max()]
+    data_min = img_arr_data.min()
+    data_max = img_arr_data.max()
+
+    if data_min != data_max:
+        img_arr_data = img_arr_data[img_arr_data != data_min]
+        img_arr_data = img_arr_data[img_arr_data != data_max]
 
     std = img_arr_data.std()
     if std == 0:

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -114,8 +114,13 @@ def verify_normalized_ouput(normalized, expected_shape, expected_std=1.0):
     # Make consistant with the norm function, which removes min and max values
     normalized_numpy = normalized.numpy()
     normalized_numpy = normalized_numpy.flatten()
-    normalized_numpy = normalized_numpy[normalized_numpy != normalized_numpy.min()]
-    normalized_numpy = normalized_numpy[normalized_numpy != normalized_numpy.max()]
+    data_min = normalized_numpy.min()
+    data_max = normalized_numpy.max()
+
+    if data_min != data_max:
+        normalized_numpy = normalized_numpy[normalized_numpy != data_min]
+        normalized_numpy = normalized_numpy[normalized_numpy != data_max]
+
     # Check normalization (should have mean ~0 and std ~1)
     assert abs(normalized_numpy.mean()) < 1e-6  # Close to zero
     assert abs(normalized_numpy.std() - expected_std) < 1e-6  # Close to one

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -22,7 +22,7 @@ class TestExtractFeatures:
     @pytest.mark.parametrize(
         ["n_bands", "width", "height"],
         [
-            (3, 1, 1),  # too small to be processed by the model, requires padding
+            (3, 2, 2),  # too small to be processed by the model, requires padding
             (3, 8, 8),  # too small to be processed by the model, requires padding
             (3, 16, 16),  # smallest size that can natively be processed by the model
             (3, 61, 39),  # not divisible by 16 so requires padding in both directions


### PR DESCRIPTION
Hi @cwmeijer, today I reproduced the error on prediction. 
I checked it a bit. Basically, I found commits until [1db6559](https://github.com/DroneML/pycoeus/commit/1db6559fa3c70c1edfad8ed1ae961eed0f1cce28) works, but everything after it doesn't. So it's likely we introduced some error in PR #70.

I narrowed the bug down to the feature extractor, because:

- When using previously (before 1db6559) extracted feature, the lastest main works. So the prediction should be fine.
- When forcing extracting features, no matter using old or new feature extraction model, prediction fails. So it's likely not the model which is run.

In the end, I rolled several lines back to previous, according to your changes in PR #70. This solves the problem, but I do not know why, and they may have side effects. When you have time, could you please give this PR a look? maybe you directly see what's wrong.

This is the prediction after fix, I think it's working, I just did not draw the labels as good as you:
![image](https://github.com/user-attachments/assets/b19e304b-aac8-47e6-aa1a-be2c335a1ebd)
