### PR TITLE
validate training instance numbers (fixes #77)

### DIFF
--- a/src/pycoeus/features.py
+++ b/src/pycoeus/features.py
@@ -192,6 +192,7 @@ def load_model(model_scale: float, models_dir: Path = Path("models"), sources: t
                     surfdrive_file_id = {"flair_toy_ep10_scale1_0.pth": "JzDbL9KWWj5BmtR",
                            "flair_toy_ep15_scale1_0.pth": "zFuHOf3FQBcDzWE",
                            "flair_toy_ep15_scale0_25.pth": "dvASjEyGPRLBygX",
+                           "flair_toy_ep15_scale0_125.pth": "OQJDiqA0HpX0On6",
                                          }[file_name]
                     url = f"https://surfdrive.surf.nl/files/index.php/s/{surfdrive_file_id}/download"
                     wget.download(url, out=str(model_path))

--- a/src/pycoeus/main.py
+++ b/src/pycoeus/main.py
@@ -182,12 +182,11 @@ def prepare_training_data(input_data, labels):
     negative_instances = input_data.reshape((input_data.shape[0], -1))[:, flattened == 0].transpose()
     n_labeled = flattened.shape[0]
     n_unlabeled = np.prod(labels.shape[-2:]) - n_labeled
-    logger.info(
-        f"Dataset contains {n_labeled} ({round(100 * n_labeled / (n_labeled + n_unlabeled), 2)}%) labeled instances of a total of {n_labeled + n_unlabeled} instances."
-    )
+
+    _validate_and_log_instance_numbers(negative_instances.shape[0], positive_instances.shape[0], n_labeled, n_unlabeled)
     # Subsample training data
-    sampled_positive_instances = subsample(positive_instances, 10000)
-    sampled_negative_instances = subsample(negative_instances, 10000)
+    sampled_positive_instances = _subsample(positive_instances, 10000)
+    sampled_negative_instances = _subsample(negative_instances, 10000)
     n_sampled_positive = sampled_positive_instances.shape[0]
     n_sampled_negative = sampled_negative_instances.shape[0]
     n_sampled_labeled = n_sampled_negative + n_sampled_positive
@@ -211,7 +210,20 @@ def prepare_training_data(input_data, labels):
     return train_data, train_labels
 
 
-def subsample(instances, sample_size):
+def _validate_and_log_instance_numbers(n_negative, n_positive, n_labeled, n_unlabeled):
+    missing_msg = "Zero %s found in training data. Positive and negative labels are required for training a model."
+    if n_labeled == 0:
+        raise ValueError(missing_msg % "labeled instances")
+    if n_positive == 0:
+        raise ValueError(missing_msg % "positive labeled instances")
+    if n_negative == 0:
+        raise ValueError(missing_msg % "negative labeled instances")
+    logger.info(
+        f"Dataset contains {n_labeled} ({round(100 * n_labeled / (n_labeled + n_unlabeled), 2)}%) labeled instances of a total of {n_labeled + n_unlabeled} instances."
+    )
+
+
+def _subsample(instances, sample_size):
     if isinstance(instances, da.Array):
         instances.compute_chunk_sizes()
     n_instances = instances.shape[0]
@@ -245,7 +257,7 @@ def _set_compute_mode(compute_mode: Literal["normal", "parallel", "safe"], chunk
     return dask_kwargs
 
 
-def parse_args():
+def _parse_args():
     parser = argparse.ArgumentParser(
         description="Classify pixels in the input image using a model trained on the labels."
     )
@@ -295,7 +307,7 @@ def parse_args():
 
 
 if __name__ == "__main__":
-    args = parse_args()
+    args = _parse_args()
     input_path = args.input
     pos_labels_path = args.pos_labels
     neg_labels_path = args.neg_labels

--- a/src/pycoeus/main.py
+++ b/src/pycoeus/main.py
@@ -180,10 +180,9 @@ def prepare_training_data(input_data, labels):
     flattened = class1_labels.flatten()
     positive_instances = input_data.reshape((input_data.shape[0], -1))[:, flattened == 1].transpose()
     negative_instances = input_data.reshape((input_data.shape[0], -1))[:, flattened == 0].transpose()
-    n_labeled = flattened.shape[0]
-    n_unlabeled = np.prod(labels.shape[-2:]) - n_labeled
+    n_total_instances = np.prod(labels.shape[-2:])
 
-    _validate_and_log_instance_numbers(negative_instances.shape[0], positive_instances.shape[0], n_labeled, n_unlabeled)
+    _validate_and_log_instance_numbers(negative_instances.shape[0], positive_instances.shape[0], n_total_instances)
     # Subsample training data
     sampled_positive_instances = _subsample(positive_instances, 10000)
     sampled_negative_instances = _subsample(negative_instances, 10000)
@@ -210,8 +209,10 @@ def prepare_training_data(input_data, labels):
     return train_data, train_labels
 
 
-def _validate_and_log_instance_numbers(n_negative, n_positive, n_labeled, n_unlabeled):
-    missing_msg = "Zero %s found in training data. Positive and negative labels are required for training a model."
+def _validate_and_log_instance_numbers(n_negative, n_positive, n_total_instances):
+    n_labeled = n_negative + n_positive
+    n_unlabeled = n_total_instances - n_labeled
+    missing_msg = "Zero %s found in training data. Positive and negative labels are required to train a model."
     if n_labeled == 0:
         raise ValueError(missing_msg % "labeled instances")
     if n_positive == 0:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -101,10 +101,10 @@ def test_prepare_training_data(array_type):
 ])
 def test_zero_positive_labels_raises_value_error(label_options):
     print(f"{label_options=}")
-    random = np.random.default_rng(0)
+    rng = np.random.default_rng(0)
     length = 200
-    random_data = random.integers(low=0, high=256, size=(5, length, length))
-    labels = random.choice(label_options, size=(1, length, length), replace=True)
+    random_data = rng.integers(low=0, high=256, size=(5, length, length))
+    labels = rng.choice(label_options, size=(1, length, length), replace=True)
 
     with pytest.raises(ValueError):
         prepare_training_data(random_data, labels)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -95,6 +95,20 @@ def test_prepare_training_data(array_type):
 
     prepare_training_data(input_data, labels)
 
+@pytest.mark.parametrize("label_options", [
+    [1,2],  # no negative labels
+    [0,2],  # no positive labels
+])
+def test_zero_positive_labels_raises_value_error(label_options):
+    print(f"{label_options=}")
+    random = np.random.default_rng(0)
+    length = 200
+    random_data = random.integers(low=0, high=256, size=(5, length, length))
+    labels = random.choice(label_options, size=(1, length, length), replace=True)
+
+    with pytest.raises(ValueError):
+        prepare_training_data(random_data, labels)
+
 
 def train_predict_score(features, raster, tmpdir, use_case):
     pos_gdf = gpd.read_file(TEST_DATA_FOLDER / use_case.labels_pos_filename).to_crs(raster.rio.crs)


### PR DESCRIPTION
Fixes #77 and #61 (as they are about the same issue)
- Also fixes a missing model link in the surfdrive downloader.
- Renames some methods to indicate they're private (add underscore)
