### PR TITLE
add labels to prediction bands

### DIFF
--- a/src/pycoeus/main.py
+++ b/src/pycoeus/main.py
@@ -98,7 +98,7 @@ def read_input_and_labels_and_save_predictions(
     prediction_raster = raster.isel(band=0).drop_vars(["band"]).expand_dims(band=prediction_map.shape[0])
     prediction_raster.data = prediction_map
 
-    # Covert prediction_raster to xr.Dataset then preserve band names
+    # Convert prediction_raster to xr.Dataset then preserve band names
     prediction_raster = prediction_raster.assign_coords({"band": ["Negative", "Positive"]})
     prediction_raster = prediction_raster.to_dataset(dim="band")
     prediction_raster["Negative"].attrs["long_name"] = "Negative"


### PR DESCRIPTION
Fix #82 .

Labels are added to bands in tiff file by configuring the `attr` field `long_name`.  The results in QGIS is as follow:

![image](https://github.com/user-attachments/assets/541c07f3-9915-41ec-b7f4-4f516da3fd58)
